### PR TITLE
Fix autoload cookie

### DIFF
--- a/pycarddavel.el
+++ b/pycarddavel.el
@@ -84,7 +84,7 @@ CANDIDATE is ignored."
                       "Select" #'pycarddavel--helm-source-select-action))
    (requires-pattern :initform 0)))
 
-;;;#autoload
+;;;###autoload
 (defun pycarddavel-search-with-helm ()
   "Start helm to select your contacts from a list."
   (interactive)


### PR DESCRIPTION
Three hash marks are necessary.

See also
- http://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html
